### PR TITLE
Added link to Cal Trustworthy Deep Learning course

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ If you want to contribute to this list (*and please do!*) read over the [contrib
 * [Fairness in Machine Learning](https://fairmlclass.github.io/)
 * [Human-Center Machine Learning](http://courses.mpi-sws.org/hcml-ws18/)
 * [Practical Model Interpretability](https://github.com/jphall663/GWU_data_mining/blob/master/10_model_interpretability/10_model_interpretability.md)
+* [Trustworthy Deep Learning] (https://berkeley-deep-learning.github.io/cs294-131-s19/)
 
 ## Interpretable ("Whitebox") or Fair Modeling Packages
 


### PR DESCRIPTION
CS 294-131: Trustworthy Deep Learning (Special Topics in Deep Learning) 
https://berkeley-deep-learning.github.io/cs294-131-s19/